### PR TITLE
#222 Fire created when timer goes below 0 for cooking an item

### DIFF
--- a/source/core/src/main/com/csse3200/game/areas/ForestGameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/ForestGameArea.java
@@ -661,6 +661,10 @@ public class ForestGameArea extends GameArea {
     spawnController.getEvents().addListener(PersonalCustomerEnums.MOONKI.name(), this::spawnMoonki);
     spawnController.getEvents().addListener(PersonalCustomerEnums.BASIC_SHEEP.name(), this::spawnBasicSheep);
     spawnController.getEvents().addListener(PersonalCustomerEnums.BASIC_CHICKEN.name(), this::spawnBasicChicken);
+
+    // Called on the game area as this can happen in any game area
+    spawnController.getEvents().addListener("SpawnFlame", this::spawnFlame);
+
     return spawnController;
   }
 

--- a/source/core/src/main/com/csse3200/game/areas/GameArea.java
+++ b/source/core/src/main/com/csse3200/game/areas/GameArea.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Disposable;
 import com.csse3200.game.areas.terrain.TerrainComponent;
 import com.csse3200.game.entities.Entity;
+import com.csse3200.game.entities.factories.StationFactory;
 import com.csse3200.game.services.ServiceLocator;
 
 import java.util.ArrayList;
@@ -42,6 +43,24 @@ public abstract class GameArea implements Disposable {
   protected void spawnEntity(Entity entity) {
     areaEntities.add(entity);
     ServiceLocator.getEntityService().register(entity);
+  }
+
+  static int staticX = 1;
+  static int staticY = 3;
+
+  public static void setStaticXY(int x, int y) {
+    staticX = x;
+    staticY = y;
+  }
+
+  protected void spawnFlame(String type) {
+    GridPoint2 flamePos = new GridPoint2(staticX,staticY + 1);
+    Entity flame = StationFactory.createFlame();
+    spawnEntityAt(flame, flamePos, false, false);
+
+    GridPoint2 fireExtinguisherPos = new GridPoint2(staticX, staticY);
+    Entity fireExtinguisher = StationFactory.createFireExtinguisher();
+    spawnEntityAt(fireExtinguisher, fireExtinguisherPos, false, false);
   }
 
   /**

--- a/source/core/src/main/com/csse3200/game/components/items/CookIngredientComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/items/CookIngredientComponent.java
@@ -1,5 +1,7 @@
 package com.csse3200.game.components.items;
 
+import com.badlogic.gdx.math.Vector2;
+import com.csse3200.game.areas.GameArea;
 import com.csse3200.game.components.Component;
 import com.csse3200.game.services.GameTime;
 import com.csse3200.game.services.ServiceLocator;
@@ -45,14 +47,24 @@ public class CookIngredientComponent extends Component {
             long current_time = timesource.getTime();
 
             // If 15 seconds have passed since the item was cooked,
-            // the item gets burnt
+            // the item gets burnt and flame is made
             if (current_time >= cookEndTime + 15 * 1000L) {
                 ingredient.burnItem();
+                this.setFire();
                 stopCookingIngredient();
             } else if (current_time >= cookEndTime) {
                 ingredient.cookItem();
             }
         }
+    }
+
+    /**
+     * Creates a flame at the given stations position
+     */
+    void setFire() {
+        Vector2 pos = entity.getPosition();
+        GameArea.setStaticXY((int) pos.x, (int) pos.y);
+        entity.getEvents().trigger("StartFlame");
     }
 
     /**

--- a/source/core/src/main/com/csse3200/game/entities/factories/StationFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/StationFactory.java
@@ -262,19 +262,13 @@ public class StationFactory {
 
   public static Entity createFlame() {
     Entity flame = new Entity()
-            .addComponent(new FlameComponent())
-            .addComponent(new PhysicsComponent())
-            .addComponent(new InteractionComponent(PhysicsLayer.INTERACTABLE));
+            .addComponent(new FlameComponent());
     AnimationRenderComponent animator =
             new AnimationRenderComponent(
                     ServiceLocator.getResourceService().getAsset("images/fireExtinguisher/atlas/flame.atlas", TextureAtlas.class));
-    System.out.println("Adding flame animation");
     animator.addAnimation("flame", 0.1f, Animation.PlayMode.LOOP);
-    System.out.println("Done adding flame animation");
 
     flame.addComponent(animator);
-
-    flame.getComponent(PhysicsComponent.class).setBodyType(BodyType.StaticBody);
     return flame;
   }
 }


### PR DESCRIPTION
# Description
A station creates a fire if the ingredient is burned when being cooked in a station.

Closes (#222)

## Type of change
- [x] New feature (non-breaking change which adds functionality)\
- [ ] This change requires a documentation update

# How Has This Been Tested?
There was already existing testing for this feature, the fire just needed to be created without breaking the code.

- [x] [testIngredientBecomesBurnt](https://github.com/UQcsse3200/2024-studio-3/blob/main/source/core/src/test/com/csse3200/game/components/items/CookIngredientComponentTest.java)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
