### PR TITLE
Added tests in MainGameOrderTicketDisplayTest to check for DocketMealDisplay.

### DIFF
--- a/source/core/src/test/com/csse3200/game/components/ordersystem/MainGameOrderTicketDisplayTest.java
+++ b/source/core/src/test/com/csse3200/game/components/ordersystem/MainGameOrderTicketDisplayTest.java
@@ -67,7 +67,10 @@ class MainGameOrderTicketDisplayTest {
 		textureMock = mock(Texture.class);
 
 		lenient().when(resourceService.getAsset("images/ordersystem/acai_bowl_docket.png", Texture.class)).thenReturn(textureMock);
-
+		lenient().when(resourceService.getAsset("images/ordersystem/steak_meal_docket.png", Texture.class)).thenReturn(textureMock);
+		lenient().when(resourceService.getAsset("images/ordersystem/salad_docket.png", Texture.class)).thenReturn(textureMock);
+		lenient().when(resourceService.getAsset("images/ordersystem/fruit_salad_docket.png", Texture.class)).thenReturn(textureMock);
+		lenient().when(resourceService.getAsset("images/ordersystem/banana_split_docket.png", Texture.class)).thenReturn(textureMock);
 
 		when(ServiceLocator.getRenderService().getStage()).thenReturn(stage);
 		when(ServiceLocator.getRenderService().getStage().getViewport()).thenReturn(viewport);
@@ -271,6 +274,59 @@ class MainGameOrderTicketDisplayTest {
 
 		assertEquals("acaiBowl", recipe.getName(), "The recipe name should be 'acaiBowl'");
 	}
+
+	/**
+	 * Tests that steak meal is displayed correctly.
+	 */
+	@Test
+	void testSteakMeal() {
+		orderTicketDisplay.setRecipe("steakMeal");
+		orderTicketDisplay.create();
+		orderTicketDisplay.addActors();
+
+		Table table = MainGameOrderTicketDisplay.getTableArrayList().getFirst();
+		assertNotNull(table, "Table should not be null for steakMeal");
+	}
+
+	/**
+	 * Tests that salad is displayed correctly.
+	 */
+	@Test
+	void testSalad() {
+		orderTicketDisplay.setRecipe("salad");
+		orderTicketDisplay.create();
+		orderTicketDisplay.addActors();
+
+		Table table = MainGameOrderTicketDisplay.getTableArrayList().getFirst();
+		assertNotNull(table, "Table should not be null for salad");
+	}
+
+	/**
+	 * Tests that fruit salad is displayed correctly.
+	 */
+	@Test
+	void testFruitSalad() {
+		orderTicketDisplay.setRecipe("fruitSalad");
+		orderTicketDisplay.create();
+		orderTicketDisplay.addActors();
+
+		Table table = MainGameOrderTicketDisplay.getTableArrayList().getFirst();
+		assertNotNull(table, "Table should not be null for fruitSalad");
+	}
+
+	/**
+	 * Tests that banana split is displayed correctly.
+	 */
+	@Test
+	void testBananaSplit() {
+		orderTicketDisplay.setRecipe("bananaSplit");
+		orderTicketDisplay.create();
+		orderTicketDisplay.addActors();
+
+		Table table = MainGameOrderTicketDisplay.getTableArrayList().getFirst();
+		assertNotNull(table, "Table should not be null for bananaSplit");
+	}
+
 
 	@Test
 	void testGetZIndex() {


### PR DESCRIPTION
# Description

Added four tests to check whether meal docket images were being called for their respective meal string in MainGameOrderTicketDisplayTest. 

## Type of change

Please delete options that are not relevant.

- [x] New tests
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] testSteakMeal()
- [x] testSalad() 
- [x] testFruitSalad()
- [x] testBananaSplit()
- [x] Also by visual render of the dockets during playtime. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
