### PR TITLE
Move Team 7 Player holding items code to its own class

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/player/InventoryDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/player/InventoryDisplay.java
@@ -93,140 +93,6 @@ public class InventoryDisplay extends UIComponent {
 
         stage.addActor(table);
     }
-    /**
-     * Updates the label to reflect the current item in the first slot of the inventory.
-     * @param item the item in the first slot of the inventory
-     */
-
-    private void updateLabel(ItemComponent item) {
-        // Update the label with the item information
-        /*
-        String itemText = String.format("Current Item: %s", item != null ? item.getItemName() : "None");
-        if (label == null) {
-            label = new Label(itemText, skin);
-            label.setFontScale(2f);
-        } else {
-            label.setText(itemText); // Update the label text
-            //Update player sprite
-         */
-        if (item != null) {
-            if (item instanceof IngredientComponent) {
-                switch (item.getItemType()) {
-                    case ItemType.ACAI:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawAcai");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedAcai");
-                        }
-                        break;
-                    case ItemType.BEEF:
-                        //Updates player sprite back to hold fish (raw, cooked, burnt)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawBeef");
-                        } else if (((IngredientComponent) item).getItemState().equals("cooked")) {
-                            entity.getEvents().trigger("updateAnimationCookedBeef");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationBurntBeef");
-                        }
-                    case ItemType.BANANA:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawBanana");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedBanana");
-                        }
-                        break;
-                    case ItemType.LETTUCE:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawLettuce");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedLettuce");
-                        }
-                        break;
-                    case ItemType.CUCUMBER:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawCucumber");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedCucumber");
-                        }
-                        break;
-                    case ItemType.TOMATO:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawTomato");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedTomato");
-                        }
-                        break;
-                    case ItemType.STRAWBERRY:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawStrawberry");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedStrawberry");
-                        }
-                        break;
-                    case ItemType.CHOCOLATE:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawChocolate");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedChocolate");
-                        }
-                        break;
-                    case ItemType.FISH:
-                        //Updates player sprite back to hold fish (raw or cooked)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawFish");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationCookedFish");
-                        }
-                        break;
-                    case ItemType.ACAIBOWL:
-                        //Updates player sprite back to hold acai bowl
-                        entity.getEvents().trigger("updateAnimationAcaiBowl");
-                        break;
-                    case ItemType.BANANASPLIT:
-                        //Updates player sprite back to hold banana split
-                        entity.getEvents().trigger("updateAnimationBananaSplit");
-                        break;
-                    case ItemType.FRUITSALAD:
-                        //Updates player sprite back to hold fruit salad
-                        entity.getEvents().trigger("updateAnimationFruitSalad");
-                        break;
-                    case ItemType.SALAD:
-                        //Updates player sprite back to hold salad
-                        entity.getEvents().trigger("updateAnimationSalad");
-                        break;
-                    case ItemType.STEAKMEAL:
-                        //Updates player sprite back to hold steak meal
-                        entity.getEvents().trigger("updateAnimationSteak");
-                        break;
-                    default:
-                        //Updates player sprite back to default
-                        entity.getEvents().trigger("updateAnimationEmptyInventory");
-                        break;
-                }
-            } else {
-                switch(item.getItemType()) {
-                    case PLATE:
-                        entity.getEvents().trigger("updateAnimationPlate");
-                        break;
-                    case FIREEXTINGUISHER:
-                        entity.getEvents().trigger(
-                            "updateAnimationFireExtinguisher");
-                        break;
-                }
-            }
-        } else {
-            //Updates player sprite back to default
-            entity.getEvents().trigger("updateAnimationEmptyInventory");
-        }
-    }
-
 
     /**
      * Updates the UI display to reflect the current state of the InventoryComponent
@@ -267,7 +133,7 @@ public class InventoryDisplay extends UIComponent {
     public void update() {
         // updateLabel(entity.getComponent(InventoryComponent.class).getItemFirst());
         updateDisplay();
-        updateLabel(entity.getComponent(InventoryComponent.class).getItemFirst());
+        //updateLabel(entity.getComponent(InventoryComponent.class).getItemFirst());
     }
 
     @Override

--- a/source/core/src/main/com/csse3200/game/components/player/PlayerItemSpriteManager.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerItemSpriteManager.java
@@ -32,6 +32,10 @@ public class PlayerItemSpriteManager extends Component {
         }
     }
 
+    /**
+     * Updates the player sprite to show it holding the item provided.
+     * @param item The item to show the player sprite holding.
+     */
     private void updatePlayerSprite(ItemComponent item) {
         if (item != null) {
             if (item instanceof IngredientComponent) {
@@ -151,6 +155,10 @@ public class PlayerItemSpriteManager extends Component {
         }
     }
 
+    /**
+     * Updates the player sprite to match what is currently being held in
+     * the player's InventoryComponent
+     */
     public void update() {
         if (entity != null) {
             updatePlayerSprite(entity.getComponent(InventoryComponent.class).getItemFirst());

--- a/source/core/src/main/com/csse3200/game/components/player/PlayerItemSpriteManager.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerItemSpriteManager.java
@@ -1,0 +1,159 @@
+
+package com.csse3200.game.components.player;
+
+import java.util.ArrayList;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.scenes.scene2d.Stage;
+import com.badlogic.gdx.scenes.scene2d.ui.Image;
+import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.badlogic.gdx.scenes.scene2d.ui.Stack;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
+import com.csse3200.game.components.items.IngredientComponent;
+import com.csse3200.game.components.items.ItemType;
+import com.csse3200.game.components.items.PlateComponent;
+import com.csse3200.game.services.ServiceLocator;
+import com.csse3200.game.components.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.csse3200.game.components.player.InventoryComponent;
+import com.csse3200.game.components.items.ItemComponent;
+import com.csse3200.game.rendering.TextureRenderComponent;
+
+/**
+ * A class that handles updating the player sprite to display what the
+ * player is currently holding in their hand.
+ */
+public class PlayerItemSpriteManager extends Component {
+    public PlayerItemSpriteManager() {
+        if (entity != null) {
+            // listener for when the player's InventoryComponent is updated
+            entity.getEvents().addListener("updateInventory", this::update);
+        }
+    }
+
+    private void updatePlayerSprite(ItemComponent item) {
+        if (item != null) {
+            if (item instanceof IngredientComponent) {
+                switch (item.getItemType()) {
+                    case ItemType.ACAI:
+                        //Updates player sprite back to hold fish (raw or chopped)
+                        if (((IngredientComponent) item).getItemState().equals("raw")) {
+                            entity.getEvents().trigger("updateAnimationRawAcai");
+                        } else {
+                            entity.getEvents().trigger("updateAnimationChoppedAcai");
+                        }
+                        break;
+                    case ItemType.BEEF:
+                        //Updates player sprite back to hold fish (raw, cooked, burnt)
+                        if (((IngredientComponent) item).getItemState().equals("raw")) {
+                            entity.getEvents().trigger("updateAnimationRawBeef");
+                        } else if (((IngredientComponent) item).getItemState().equals("cooked")) {
+                            entity.getEvents().trigger("updateAnimationCookedBeef");
+                        } else {
+                            entity.getEvents().trigger("updateAnimationBurntBeef");
+                        }
+                    case ItemType.BANANA:
+                        //Updates player sprite back to hold fish (raw or chopped)
+                        if (((IngredientComponent) item).getItemState().equals("raw")) {
+                            entity.getEvents().trigger("updateAnimationRawBanana");
+                        } else {
+                            entity.getEvents().trigger("updateAnimationChoppedBanana");
+                        }
+                        break;
+                    case ItemType.LETTUCE:
+                        //Updates player sprite back to hold fish (raw or chopped)
+                        if (((IngredientComponent) item).getItemState().equals("raw")) {
+                            entity.getEvents().trigger("updateAnimationRawLettuce");
+                        } else {
+                            entity.getEvents().trigger("updateAnimationChoppedLettuce");
+                        }
+                        break;
+                    case ItemType.CUCUMBER:
+                        //Updates player sprite back to hold fish (raw or chopped)
+                        if (((IngredientComponent) item).getItemState().equals("raw")) {
+                            entity.getEvents().trigger("updateAnimationRawCucumber");
+                        } else {
+                            entity.getEvents().trigger("updateAnimationChoppedCucumber");
+                        }
+                        break;
+                    case ItemType.TOMATO:
+                        //Updates player sprite back to hold fish (raw or chopped)
+                        if (((IngredientComponent) item).getItemState().equals("raw")) {
+                            entity.getEvents().trigger("updateAnimationRawTomato");
+                        } else {
+                            entity.getEvents().trigger("updateAnimationChoppedTomato");
+                        }
+                        break;
+                    case ItemType.STRAWBERRY:
+                        //Updates player sprite back to hold fish (raw or chopped)
+                        if (((IngredientComponent) item).getItemState().equals("raw")) {
+                            entity.getEvents().trigger("updateAnimationRawStrawberry");
+                        } else {
+                            entity.getEvents().trigger("updateAnimationChoppedStrawberry");
+                        }
+                        break;
+                    case ItemType.CHOCOLATE:
+                        //Updates player sprite back to hold fish (raw or chopped)
+                        if (((IngredientComponent) item).getItemState().equals("raw")) {
+                            entity.getEvents().trigger("updateAnimationRawChocolate");
+                        } else {
+                            entity.getEvents().trigger("updateAnimationChoppedChocolate");
+                        }
+                        break;
+                    case ItemType.FISH:
+                        //Updates player sprite back to hold fish (raw or cooked)
+                        if (((IngredientComponent) item).getItemState().equals("raw")) {
+                            entity.getEvents().trigger("updateAnimationRawFish");
+                        } else {
+                            entity.getEvents().trigger("updateAnimationCookedFish");
+                        }
+                        break;
+                    case ItemType.ACAIBOWL:
+                        //Updates player sprite back to hold acai bowl
+                        entity.getEvents().trigger("updateAnimationAcaiBowl");
+                        break;
+                    case ItemType.BANANASPLIT:
+                        //Updates player sprite back to hold banana split
+                        entity.getEvents().trigger("updateAnimationBananaSplit");
+                        break;
+                    case ItemType.FRUITSALAD:
+                        //Updates player sprite back to hold fruit salad
+                        entity.getEvents().trigger("updateAnimationFruitSalad");
+                        break;
+                    case ItemType.SALAD:
+                        //Updates player sprite back to hold salad
+                        entity.getEvents().trigger("updateAnimationSalad");
+                        break;
+                    case ItemType.STEAKMEAL:
+                        //Updates player sprite back to hold steak meal
+                        entity.getEvents().trigger("updateAnimationSteak");
+                        break;
+                    default:
+                        //Updates player sprite back to default
+                        entity.getEvents().trigger("updateAnimationEmptyInventory");
+                        break;
+                }
+            } else {
+                switch(item.getItemType()) {
+                    case PLATE:
+                        entity.getEvents().trigger("updateAnimationPlate");
+                        break;
+                    case FIREEXTINGUISHER:
+                        entity.getEvents().trigger(
+                                "updateAnimationFireExtinguisher");
+                        break;
+                }
+            }
+        } else {
+            //Updates player sprite back to default
+            entity.getEvents().trigger("updateAnimationEmptyInventory");
+        }
+    }
+
+    public void update() {
+        if (entity != null) {
+            updatePlayerSprite(entity.getComponent(InventoryComponent.class).getItemFirst());
+        }
+    }
+}

--- a/source/core/src/main/com/csse3200/game/entities/factories/PlayerFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/PlayerFactory.java
@@ -7,6 +7,7 @@ import com.csse3200.game.components.maingame.CheckWinLoseComponent;
 import com.csse3200.game.components.ordersystem.MainGameOrderTicketDisplay;
 import com.csse3200.game.components.player.InventoryComponent;
 import com.csse3200.game.components.player.InventoryDisplay;
+import com.csse3200.game.components.player.PlayerItemSpriteManager;
 import com.csse3200.game.components.player.PlayerActions;
 import com.csse3200.game.components.player.PlayerStatsDisplay;
 import com.csse3200.game.components.player.*;
@@ -73,6 +74,7 @@ public class PlayerFactory {
             .addComponent(new CombatStatsComponent(config.health, config.baseAttack, ServiceLocator.getLevelService().getCurrGold()))
             .addComponent(new InventoryComponent(config.inventorySize))
             .addComponent(new InventoryDisplay())
+                .addComponent(new PlayerItemSpriteManager())
             .addComponent(inputComponent)
             .addComponent(animator)
             .addComponent(new PlayerAnimationController())


### PR DESCRIPTION
# Description

Creates a new class called PlayerItemSpriteManager and moves functionality to update the player's sprite based on what it's holding (code from Team 7) from InventoryDisplay to this new class. This helps separate out this player-specific functionality from InventoryDisplay, which will be used for more than just the player (i.e. stations).

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
