### PR TITLE
Station chopping freezing

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/player/KeyboardPlayerInputComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/player/KeyboardPlayerInputComponent.java
@@ -20,7 +20,7 @@ public class KeyboardPlayerInputComponent extends InputComponent {
   private static HashMap<Integer, Integer> keyFlags = new HashMap<>();
   private static final String WALKSTOP = "walkStop";
   //private Entity player;
-  private boolean isChopping;
+  private boolean isChopping = false;
 
   private boolean isInteracting = false;
 
@@ -44,6 +44,7 @@ public class KeyboardPlayerInputComponent extends InputComponent {
     if (isChopping && keycode != Keys.Q) {
       // We know item exits and is choppable
       entity.getEvents().trigger("interact", "stopChop");
+      isChopping = false;
     }
 
     if (keycode == Keys.O) {

--- a/source/core/src/main/com/csse3200/game/components/player/KeyboardPlayerInputComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/player/KeyboardPlayerInputComponent.java
@@ -42,7 +42,6 @@ public class KeyboardPlayerInputComponent extends InputComponent {
       entity.getEvents().trigger("createOrder");
       return true;
     }
-
     
     if (keycode == Keys.E) {
       // Trigger an interaction attempt
@@ -56,6 +55,9 @@ public class KeyboardPlayerInputComponent extends InputComponent {
       // Trigger an attempt to rotate inventory of a station to update item display
       entity.getEvents().trigger("interact", "rotate");
       return true;
+    } else if (keycode == Keys.Q) {
+      // Attempt to trigger an interaction to chops
+      entity.getEvents().trigger("interact", "chop");
     }
 
     if (!isInteracting) {
@@ -87,11 +89,6 @@ public class KeyboardPlayerInputComponent extends InputComponent {
               ServiceLocator.getEntityService().getEvents().trigger("leaveEarly");
               return true;
       }
-    }
-
-    if (keycode == Keys.SPACE) {
-      entity.getEvents().trigger("attack");
-      return true;
     }
 
     return false;

--- a/source/core/src/main/com/csse3200/game/components/player/KeyboardPlayerInputComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/player/KeyboardPlayerInputComponent.java
@@ -3,7 +3,6 @@ package com.csse3200.game.components.player;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.InputProcessor;
 import com.badlogic.gdx.math.Vector2;
-import com.csse3200.game.entities.Entity;
 import com.csse3200.game.input.InputComponent;
 import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.utils.math.Vector2Utils;
@@ -15,12 +14,13 @@ import java.util.HashMap;
  * This input handler only uses keyboard input.
  */
 public class KeyboardPlayerInputComponent extends InputComponent {
-  private static final float ROOT2INV = 1f / (float) Math.sqrt(2f);
+  //private static final float ROOT2INV = 1f / (float) Math.sqrt(2f);
   private Vector2 walkDirection = Vector2.Zero.cpy();
   public float walkSpeed = 1f;
   private static HashMap<Integer, Integer> keyFlags = new HashMap<>();
   private static final String WALKSTOP = "walkStop";
-  private Entity player;
+  //private Entity player;
+  private boolean isChopping;
 
   private boolean isInteracting = false;
 
@@ -37,6 +37,14 @@ public class KeyboardPlayerInputComponent extends InputComponent {
   @Override
   public boolean keyDown(int keycode) {
     keyFlags.put(keycode, 1);
+
+    // Check if were chopping and we recieve a different key
+    // If so stop chopping
+    // This in effect freezes the player
+    if (isChopping && keycode != Keys.Q) {
+      // We know item exits and is choppable
+      entity.getEvents().trigger("interact", "stopChop");
+    }
 
     if (keycode == Keys.O) {
       entity.getEvents().trigger("createOrder");
@@ -58,6 +66,7 @@ public class KeyboardPlayerInputComponent extends InputComponent {
     } else if (keycode == Keys.Q) {
       // Attempt to trigger an interaction to chops
       entity.getEvents().trigger("interact", "chop");
+      isChopping = true;
     }
 
     if (!isInteracting) {
@@ -105,6 +114,15 @@ public class KeyboardPlayerInputComponent extends InputComponent {
   @Override
   public boolean keyUp(int keycode) {
     keyFlags.put(keycode, 0);
+
+    // If the 'Q' key is release we want to stop chopping
+    // Also check if any other key but R is pressed too
+    if (keycode != Keys.R && (keycode == Keys.Q || isChopping)) {
+      // We know item exits and is choppable
+      entity.getEvents().trigger("interact", "stopChop");
+      isChopping = false;
+    }
+
     return switch (keycode) {
       case Keys.W, Keys.A, Keys.S, Keys.D -> {
         triggerWalkEvent();
@@ -219,18 +237,6 @@ public class KeyboardPlayerInputComponent extends InputComponent {
     // Meant to restrict movement on some stations, not a current feature and clashing
     // with existing system
     //entity.getEvents().addListener("startInteraction", this::startInteraction);
-  }
-
-  /**
-   * Called when the player is attempting to interact and there is also a station that can be interacted with
-   */
-  private void startInteraction() {
-    isInteracting = !isInteracting;
-  
-    if (isInteracting) {
-      walkDirection.set(Vector2.Zero); 
-      triggerWalkEvent();             
-    }
   }
 
   private void whenInteractionEnds() {

--- a/source/core/src/main/com/csse3200/game/components/station/IngredientStationHandlerComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/station/IngredientStationHandlerComponent.java
@@ -71,6 +71,10 @@ public class IngredientStationHandlerComponent extends Component {
      * @param type the type of interaction attempt
      */
     public void handleInteraction(InventoryComponent playerInventoryComponent, InventoryDisplay inventoryDisplay, String type) {
+        if (!type.equals("default")) { // Return if not default interaction
+            return;
+        }
+        
         if (playerInventoryComponent.isFull()) {
             // do nothing
         } else {

--- a/source/core/src/main/com/csse3200/game/components/station/StationBinComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/station/StationBinComponent.java
@@ -1,14 +1,9 @@
 package com.csse3200.game.components.station;
 
 import com.csse3200.game.components.Component;
-import com.csse3200.game.components.ScoreSystem.ScoreSystem;
 import com.csse3200.game.components.items.ItemComponent;
-import com.csse3200.game.components.ordersystem.OrderActions;
-import com.csse3200.game.components.ordersystem.TicketDetails;
 import com.csse3200.game.components.player.InventoryComponent;
 import com.csse3200.game.components.player.InventoryDisplay;
-import com.csse3200.game.rendering.AnimationRenderComponent;
-import com.csse3200.game.services.ServiceLocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +37,10 @@ public class StationBinComponent extends Component {
      * @param type the type of interaction attempt
      */
     public void handleInteraction(InventoryComponent playerInventoryComponent, InventoryDisplay inventoryDisplay, String type) {
+        if (!type.equals("default")) {
+            return; // Do nothing if not the default interaction
+        }
+
         if (playerInventoryComponent.isFull()) {
             ItemComponent item = playerInventoryComponent.getItemFirst();
             playerInventoryComponent.removeAt(0);

--- a/source/core/src/main/com/csse3200/game/components/station/StationItemHandlerComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/station/StationItemHandlerComponent.java
@@ -90,6 +90,8 @@ public class StationItemHandlerComponent extends Component {
             this.handleInteractionDefault(playerInventoryComponent, inventoryDisplay);
         } else if (type.equals("chop")) {
             this.handleInteractionChop();
+        } else if (type.equals("stopChop")) {
+            this.handleInteractionStopChop();
         } else {
             // Do nothing, other options aren't relavent...
         }
@@ -127,19 +129,13 @@ public class StationItemHandlerComponent extends Component {
     }
 
     private void handleInteractionChop() {
-        // Get if the item is currently chopping
-        Entity item = inventoryComponent.getItemFirst().getEntity();
-        boolean isChopping = item.getComponent(ChopIngredientComponent.class) != null
-        && item.getComponent(ChopIngredientComponent.class).getIsChopping();
+        // Attempt to start chopping the ingredient
+        entity.getEvents().trigger("Chop Ingredient");
+    }
 
-        // Do some action based on if its chopping or not
-        if (!isChopping) {
-            // Start chopping the ingredient
-            entity.getEvents().trigger("Chop Ingredient");
-        } else {
-            // Stop chopping ingredient
-            entity.getEvents().trigger("Stop Chopping Ingredient");
-        }
+    private void handleInteractionStopChop() {
+        // Attempt too stop chopping the ingredient
+        entity.getEvents().trigger("Stop Chopping Ingredient");
     }
 
     /**

--- a/source/core/src/main/com/csse3200/game/components/station/StationItemHandlerComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/station/StationItemHandlerComponent.java
@@ -2,12 +2,15 @@ package com.csse3200.game.components.station;
 
 import java.util.ArrayList;
 
+import com.badlogic.gdx.net.Socket;
 import com.csse3200.game.components.Component;
+import com.csse3200.game.components.items.ChopIngredientComponent;
 import com.csse3200.game.components.items.IngredientComponent;
 import com.csse3200.game.components.items.ItemComponent;
 import com.csse3200.game.components.player.InventoryComponent;
 import com.csse3200.game.components.player.InventoryDisplay;
 import com.csse3200.game.components.station.loader.StationAcceptableItemsGetter;
+import com.csse3200.game.entities.Entity;
 
 public class StationItemHandlerComponent extends Component {
     /**
@@ -83,6 +86,21 @@ public class StationItemHandlerComponent extends Component {
      * @param type the type of interaction attempt
      */
     public void handleInteraction(InventoryComponent playerInventoryComponent, InventoryDisplay inventoryDisplay, String type) {
+        if (type.equals("default")) {
+            this.handleInteractionDefault(playerInventoryComponent, inventoryDisplay);
+        } else if (type.equals("chop")) {
+            this.handleInteractionChop();
+        } else {
+            // Do nothing, other options aren't relavent...
+        }
+    }
+
+    /**
+     * Function to handle the default interaction between a player and a station.
+     * @param playerInventoryComponent
+     * @param inventoryDisplay
+     */
+    private void handleInteractionDefault(InventoryComponent playerInventoryComponent, InventoryDisplay inventoryDisplay) {
         // Pre calcs
         boolean full = playerInventoryComponent.isFull() & this.inventoryComponent.isFull();
         boolean empty = playerInventoryComponent.isEmpty() & this.inventoryComponent.isEmpty();
@@ -108,6 +126,24 @@ public class StationItemHandlerComponent extends Component {
         }
     }
 
+    private void handleInteractionChop() {
+        // Get if the item is currently chopping
+        Entity item = inventoryComponent.getItemFirst().getEntity();
+        boolean isChopping = item.getComponent(ChopIngredientComponent.class) != null
+        && item.getComponent(ChopIngredientComponent.class).getIsChopping();
+
+        System.out.println("IS CHOPPING" + isChopping);
+
+        // Do some action based on if its chopping or not
+        if (!isChopping) {
+            // Start chopping the ingredient
+            entity.getEvents().trigger("Chop Ingredient");
+        } else {
+            // Stop chopping ingredient
+            entity.getEvents().trigger("Stop Chopping Ingredient");
+        }
+    }
+
     /**
      *
      * @return current Item being stored
@@ -127,7 +163,7 @@ public class StationItemHandlerComponent extends Component {
                 break;
             case "cutting board": // Fall through
             case "blender":
-                choppingStationRecieveItem();
+                //choppingStationRecieveItem();
                 break;
             default:
                 break;

--- a/source/core/src/main/com/csse3200/game/components/station/StationItemHandlerComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/station/StationItemHandlerComponent.java
@@ -2,15 +2,12 @@ package com.csse3200.game.components.station;
 
 import java.util.ArrayList;
 
-import com.badlogic.gdx.net.Socket;
 import com.csse3200.game.components.Component;
-import com.csse3200.game.components.items.ChopIngredientComponent;
 import com.csse3200.game.components.items.IngredientComponent;
 import com.csse3200.game.components.items.ItemComponent;
 import com.csse3200.game.components.player.InventoryComponent;
 import com.csse3200.game.components.player.InventoryDisplay;
 import com.csse3200.game.components.station.loader.StationAcceptableItemsGetter;
-import com.csse3200.game.entities.Entity;
 
 public class StationItemHandlerComponent extends Component {
     /**

--- a/source/core/src/main/com/csse3200/game/components/station/StationItemHandlerComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/station/StationItemHandlerComponent.java
@@ -163,8 +163,7 @@ public class StationItemHandlerComponent extends Component {
                 break;
             case "cutting board": // Fall through
             case "blender":
-                //choppingStationRecieveItem();
-                break;
+                break; // Don't do anything since chopping is manual now :)
             default:
                 break;
         }
@@ -184,22 +183,6 @@ public class StationItemHandlerComponent extends Component {
 
         // We know item exists and is cookable
         entity.getEvents().trigger("Cook Ingredient");
-    }
-
-    /**
-     * Function to be called when a chopping station recieves the item
-     */
-    private void choppingStationRecieveItem() {
-        // First check the item is actually available and working
-        ItemComponent item = inventoryComponent.getItemFirst();
-
-        if (item.getEntity().getComponent(IngredientComponent.class) == null
-                || !item.getEntity().getComponent(IngredientComponent.class).getIsChoppable()) {
-            return; // Item doesn't exit or isn't choppable
-        }
-
-        // We know item exits and is choppable
-        entity.getEvents().trigger("Chop Ingredient");
     }
 
     /**

--- a/source/core/src/main/com/csse3200/game/components/station/StationItemHandlerComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/station/StationItemHandlerComponent.java
@@ -132,8 +132,6 @@ public class StationItemHandlerComponent extends Component {
         boolean isChopping = item.getComponent(ChopIngredientComponent.class) != null
         && item.getComponent(ChopIngredientComponent.class).getIsChopping();
 
-        System.out.println("IS CHOPPING" + isChopping);
-
         // Do some action based on if its chopping or not
         if (!isChopping) {
             // Start chopping the ingredient

--- a/source/core/src/main/com/csse3200/game/components/station/StationMealComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/station/StationMealComponent.java
@@ -81,6 +81,11 @@ public class StationMealComponent extends Component {
         System.out.printf("BEFORE STATION ITEMS: %s\n", this.inventoryComponent.getItemNames());
         System.out.printf("BEFORE PLAYER ITEMS: %s\n", playerInventoryComponent.getItemNames());
 
+        // Don't do anything if 'chop' is sent
+        if (Objects.equals(type, "chop")) {
+            return;
+        }
+
         // Check if interaction was a combine attempt
         if (Objects.equals(type, "combine")) {
             this.processMeal();


### PR DESCRIPTION
# Description
See ticket #386 for details. But added that pressing 'q' enables the player to chop an item manually and no longer allows for a player to automatically chop and item;.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Used current unit tests and in game testing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
