### PR TITLE
#279 FIxed bug with cutscene

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/cutscenes/CutsceneScreenDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/cutscenes/CutsceneScreenDisplay.java
@@ -52,6 +52,10 @@ public class CutsceneScreenDisplay extends UIComponent {
         // Initialize the text display and add it to the stage, hidden initially
         setupTextDisplay();
 
+        if (skin == null) {
+            skin = new Skin(Gdx.files.internal("flat-earth/skin/flat-earth-ui.json"));
+        }
+
         // Positioning the table at the bottom-right of the screen
         table.bottom().right();
         table.setFillParent(true);

--- a/source/core/src/main/com/csse3200/game/ui/UIComponent.java
+++ b/source/core/src/main/com/csse3200/game/ui/UIComponent.java
@@ -12,7 +12,7 @@ import com.csse3200.game.services.ServiceLocator;
  */
 public abstract class UIComponent extends RenderComponent implements Renderable {
   private static final int UI_LAYER = 3;
-  protected static Skin skin;
+  protected static Skin skin = new Skin(Gdx.files.internal("flat-earth/skin/flat-earth-ui.json"));
   protected Stage stage;
 
   public UIComponent(Skin skin) {


### PR DESCRIPTION
# Description

Fixed a bug that crashed that game when you loaded in the cutscene. This was due to the skin not being set for the text component.

Implements #279 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
The game was built and it runs correctly as well as regression testing done for the game by Caleb Murphy.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
