### PR TITLE
Animation bug fixes #464

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/player/PlayerAnimationController.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerAnimationController.java
@@ -96,17 +96,15 @@ public class PlayerAnimationController extends Component {
     
     void animateStop(Vector2 lastdirection)
     {
-        if(lastdirection.x < -0.1) {
+        if (lastdirection.x < -0.1) {
             animator.startAnimation("Character_StandLeft");
-        } else if(lastdirection.x > 0.1 ){
+        } else if (lastdirection.x > 0.1 ){
             animator.startAnimation("Character_StandRight");
         } else if (lastdirection.y < -0.1) {
             animator.startAnimation("Character_StandDown");
-        } else if(lastdirection.y > 0.1 ){
+        } else if (lastdirection.y > 0.1 ){
             animator.startAnimation("Character_StandUp");
         }
-
-        
     }
     
     void animateStandLeft() {
@@ -156,6 +154,10 @@ public class PlayerAnimationController extends Component {
      * @param atlasPath new atlas to update player animation with
      */
     public void updateAnimation(String atlasPath) {
+        // Get the current animation going and stop it
+        String currentAnimation = animator.getCurrentAnimation();
+        animator.stopAnimation(); // Will do nothing if no animation
+
         //Removes all animations
         animator.removeAnimation("Character_StandDown");
         animator.removeAnimation("Character_StandUp");
@@ -171,11 +173,9 @@ public class PlayerAnimationController extends Component {
         animator.removeAnimation("Character_DownRight");
         animator.removeAnimation("Character_UpLeft");
 
-
         //Updates atlas
         animator.updateAtlas(ServiceLocator.getResourceService().getAsset(
                 "images/player/" + atlasPath, TextureAtlas.class));
-
 
         //Adds new animations
         animator.addAnimation("Character_StandDown", 0.2f);
@@ -191,6 +191,9 @@ public class PlayerAnimationController extends Component {
         animator.addAnimation("Character_Down", 0.2f, Animation.PlayMode.LOOP);
         animator.addAnimation("Character_UpLeft", 0.2f, Animation.PlayMode.LOOP);
         animator.addAnimation("Character_Right", 0.2f, Animation.PlayMode.LOOP);
+
+        // Now restart the animation that was going
+        animator.startAnimation(currentAnimation); // Will do nothing if no animation
     }
     
 }

--- a/source/core/src/main/com/csse3200/game/components/player/PlayerItemSpriteManager.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerItemSpriteManager.java
@@ -1,35 +1,41 @@
 
 package com.csse3200.game.components.player;
 
-import java.util.ArrayList;
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.scenes.scene2d.Stage;
-import com.badlogic.gdx.scenes.scene2d.ui.Image;
-import com.badlogic.gdx.scenes.scene2d.ui.Table;
-import com.badlogic.gdx.scenes.scene2d.ui.Stack;
-import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.csse3200.game.components.items.IngredientComponent;
 import com.csse3200.game.components.items.ItemType;
-import com.csse3200.game.components.items.PlateComponent;
-import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.components.Component;
+import com.csse3200.game.components.items.ItemComponent;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.csse3200.game.components.player.InventoryComponent;
-import com.csse3200.game.components.items.ItemComponent;
-import com.csse3200.game.rendering.TextureRenderComponent;
+
 
 /**
  * A class that handles updating the player sprite to display what the
  * player is currently holding in their hand.
  */
 public class PlayerItemSpriteManager extends Component {
-    public PlayerItemSpriteManager() {
-        if (entity != null) {
-            // listener for when the player's InventoryComponent is updated
-            entity.getEvents().addListener("updateInventory", this::update);
-        }
+
+    // Logger for this class
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlayerItemSpriteManager.class);
+
+    /**
+     * Updates the player sprite to match what is currently being held in
+     * the player's InventoryComponent
+     */
+    @Override
+    public void update() {
+        updatePlayerSprite(entity.getComponent(InventoryComponent.class).getItemFirst());
+    }
+
+    /**
+     * Add the event listener to the player item sprite manager
+     */
+    @Override
+    public void create() {
+        // listener for when the player's InventoryComponent is updated
+        entity.getEvents().addListener("updateInventory", this::update);
+        LOGGER.info("PlayerItemSpriteManager created");
     }
 
     /**
@@ -37,131 +43,121 @@ public class PlayerItemSpriteManager extends Component {
      * @param item The item to show the player sprite holding.
      */
     private void updatePlayerSprite(ItemComponent item) {
-        if (item != null) {
-            if (item instanceof ItemComponent) {
-                switch (item.getItemType()) {
-                    case ItemType.ACAI:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawAcai");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedAcai");
-                        }
-                        break;
-                    case ItemType.BEEF:
-                        //Updates player sprite back to hold fish (raw, cooked, burnt)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawBeef");
-                        } else if (((IngredientComponent) item).getItemState().equals("cooked")) {
-                            entity.getEvents().trigger("updateAnimationCookedBeef");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationBurntBeef");
-                        }
-                    case ItemType.BANANA:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawBanana");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedBanana");
-                        }
-                        break;
-                    case ItemType.LETTUCE:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawLettuce");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedLettuce");
-                        }
-                        break;
-                    case ItemType.CUCUMBER:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawCucumber");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedCucumber");
-                        }
-                        break;
-                    case ItemType.TOMATO:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawTomato");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedTomato");
-                        }
-                        break;
-                    case ItemType.STRAWBERRY:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawStrawberry");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedStrawberry");
-                        }
-                        break;
-                    case ItemType.CHOCOLATE:
-                        //Updates player sprite back to hold fish (raw or chopped)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawChocolate");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationChoppedChocolate");
-                        }
-                        break;
-                    case ItemType.FISH:
-                        //Updates player sprite back to hold fish (raw or cooked)
-                        if (((IngredientComponent) item).getItemState().equals("raw")) {
-                            entity.getEvents().trigger("updateAnimationRawFish");
-                        } else {
-                            entity.getEvents().trigger("updateAnimationCookedFish");
-                        }
-                        break;
-                    case ItemType.ACAIBOWL:
-                        //Updates player sprite back to hold acai bowl
-                        entity.getEvents().trigger("updateAnimationAcaiBowl");
-                        break;
-                    case ItemType.BANANASPLIT:
-                        //Updates player sprite back to hold banana split
-                        entity.getEvents().trigger("updateAnimationBananaSplit");
-                        break;
-                    case ItemType.FRUITSALAD:
-                        //Updates player sprite back to hold fruit salad
-                        entity.getEvents().trigger("updateAnimationFruitSalad");
-                        break;
-                    case ItemType.SALAD:
-                        //Updates player sprite back to hold salad
-                        entity.getEvents().trigger("updateAnimationSalad");
-                        break;
-                    case ItemType.STEAKMEAL:
-                        //Updates player sprite back to hold steak meal
-                        entity.getEvents().trigger("updateAnimationSteak");
-                        break;
-                    default:
-                        //Updates player sprite back to default
-                        entity.getEvents().trigger("updateAnimationEmptyInventory");
-                        break;
-                }
-            } else {
-                switch(item.getItemType()) {
-                    case PLATE:
-                        entity.getEvents().trigger("updateAnimationPlate");
-                        break;
-                    case FIREEXTINGUISHER:
-                        entity.getEvents().trigger(
-                                "updateAnimationFireExtinguisher");
-                        break;
-                }
-            }
-        } else {
-            //Updates player sprite back to default
+        if (item == null) { // All items should have this?????
+            //Updates player sprite to default
             entity.getEvents().trigger("updateAnimationEmptyInventory");
+            LOGGER.info("PlayerItemSpriteManager animation updated");
+            return;
         }
+
+        // Update the animation based on the item and its state
+        switch (item.getItemType()) {
+            case ItemType.ACAI:
+                //Updates player sprite back to hold fish (raw or chopped)
+                if (((IngredientComponent) item).getItemState().equals("raw")) {
+                    entity.getEvents().trigger("updateAnimationRawAcai");
+                } else {
+                    entity.getEvents().trigger("updateAnimationChoppedAcai");
+                }
+                break;
+            case ItemType.BEEF:
+                //Updates player sprite back to hold fish (raw, cooked, burnt)
+                if (((IngredientComponent) item).getItemState().equals("raw")) {
+                    entity.getEvents().trigger("updateAnimationRawBeef");
+                } else if (((IngredientComponent) item).getItemState().equals("cooked")) {
+                    entity.getEvents().trigger("updateAnimationCookedBeef");
+                } else {
+                    entity.getEvents().trigger("updateAnimationBurntBeef");
+                }
+                break;
+            case ItemType.BANANA:
+                //Updates player sprite back to hold fish (raw or chopped)
+                if (((IngredientComponent) item).getItemState().equals("raw")) {
+                    entity.getEvents().trigger("updateAnimationRawBanana");
+                } else {
+                    entity.getEvents().trigger("updateAnimationChoppedBanana");
+                }
+                break;
+            case ItemType.LETTUCE:
+                //Updates player sprite back to hold fish (raw or chopped)
+                if (((IngredientComponent) item).getItemState().equals("raw")) {
+                    entity.getEvents().trigger("updateAnimationRawLettuce");
+                } else {
+                    entity.getEvents().trigger("updateAnimationChoppedLettuce");
+                }
+                break;
+            case ItemType.CUCUMBER:
+                //Updates player sprite back to hold fish (raw or chopped)
+                if (((IngredientComponent) item).getItemState().equals("raw")) {
+                    entity.getEvents().trigger("updateAnimationRawCucumber");
+                } else {
+                    entity.getEvents().trigger("updateAnimationChoppedCucumber");
+                }
+                break;
+            case ItemType.TOMATO:
+                //Updates player sprite back to hold fish (raw or chopped)
+                if (((IngredientComponent) item).getItemState().equals("raw")) {
+                    entity.getEvents().trigger("updateAnimationRawTomato");
+                } else {
+                    entity.getEvents().trigger("updateAnimationChoppedTomato");
+                }
+                break;
+            case ItemType.STRAWBERRY:
+                //Updates player sprite back to hold fish (raw or chopped)
+                if (((IngredientComponent) item).getItemState().equals("raw")) {
+                    entity.getEvents().trigger("updateAnimationRawStrawberry");
+                } else {
+                    entity.getEvents().trigger("updateAnimationChoppedStrawberry");
+                }
+                break;
+            case ItemType.CHOCOLATE:
+                //Updates player sprite back to hold fish (raw or chopped)
+                if (((IngredientComponent) item).getItemState().equals("raw")) {
+                    entity.getEvents().trigger("updateAnimationRawChocolate");
+                } else {
+                    entity.getEvents().trigger("updateAnimationChoppedChocolate");
+                }
+                break;
+            case ItemType.FISH:
+                //Updates player sprite back to hold fish (raw or cooked)
+                if (((IngredientComponent) item).getItemState().equals("raw")) {
+                    entity.getEvents().trigger("updateAnimationRawFish");
+                } else {
+                    entity.getEvents().trigger("updateAnimationCookedFish");
+                }
+                break;
+            case ItemType.ACAIBOWL:
+                //Updates player sprite back to hold acai bowl
+                entity.getEvents().trigger("updateAnimationAcaiBowl");
+                break;
+            case ItemType.BANANASPLIT:
+                //Updates player sprite back to hold banana split
+                entity.getEvents().trigger("updateAnimationBananaSplit");
+                break;
+            case ItemType.FRUITSALAD:
+                //Updates player sprite back to hold fruit salad
+                entity.getEvents().trigger("updateAnimationFruitSalad");
+                break;
+            case ItemType.SALAD:
+                //Updates player sprite back to hold salad
+                entity.getEvents().trigger("updateAnimationSalad");
+                break;
+            case ItemType.STEAKMEAL:
+                //Updates player sprite back to hold steak meal
+                entity.getEvents().trigger("updateAnimationSteak");
+                break;
+            case ItemType.PLATE:
+                entity.getEvents().trigger("updateAnimationPlate");
+                break;
+            case ItemType.FIREEXTINGUISHER:
+                entity.getEvents().trigger("updateAnimationFireExtinguisher");
+                break;
+            default:
+                //Updates player sprite back to default
+                entity.getEvents().trigger("updateAnimationEmptyInventory");
+                break;
+        }
+        LOGGER.info("PlayerItemSpriteManager animation updated");
     }
 
-    /**
-     * Updates the player sprite to match what is currently being held in
-     * the player's InventoryComponent
-     */
-    public void update() {
-        if (entity != null) {
-            updatePlayerSprite(entity.getComponent(InventoryComponent.class).getItemFirst());
-        }
-    }
 }

--- a/source/core/src/main/com/csse3200/game/components/player/PlayerItemSpriteManager.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerItemSpriteManager.java
@@ -9,7 +9,6 @@ import com.csse3200.game.components.items.ItemComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * A class that handles updating the player sprite to display what the
  * player is currently holding in their hand.
@@ -23,8 +22,7 @@ public class PlayerItemSpriteManager extends Component {
      * Updates the player sprite to match what is currently being held in
      * the player's InventoryComponent
      */
-    //@Override
-    public void updateInventory() {
+    public void onUpdateInventory() {
         updatePlayerSprite(entity.getComponent(InventoryComponent.class).getItemFirst());
     }
 
@@ -34,7 +32,7 @@ public class PlayerItemSpriteManager extends Component {
     @Override
     public void create() {
         // listener for when the player's InventoryComponent is updated
-        entity.getEvents().addListener("updateInventory", this::updateInventory);
+        entity.getEvents().addListener("updateInventory", this::onUpdateInventory);
         LOGGER.info("PlayerItemSpriteManager created");
     }
 
@@ -43,7 +41,7 @@ public class PlayerItemSpriteManager extends Component {
      * @param item The item to show the player sprite holding.
      */
     private void updatePlayerSprite(ItemComponent item) {
-        if (item == null) { // All items should have this?????
+        if (item == null) { // Player inventory empty
             //Updates player sprite to default
             entity.getEvents().trigger("updateAnimationEmptyInventory");
             LOGGER.info("PlayerItemSpriteManager animation updated");

--- a/source/core/src/main/com/csse3200/game/components/player/PlayerItemSpriteManager.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerItemSpriteManager.java
@@ -23,8 +23,8 @@ public class PlayerItemSpriteManager extends Component {
      * Updates the player sprite to match what is currently being held in
      * the player's InventoryComponent
      */
-    @Override
-    public void update() {
+    //@Override
+    public void updateInventory() {
         updatePlayerSprite(entity.getComponent(InventoryComponent.class).getItemFirst());
     }
 
@@ -34,7 +34,7 @@ public class PlayerItemSpriteManager extends Component {
     @Override
     public void create() {
         // listener for when the player's InventoryComponent is updated
-        entity.getEvents().addListener("updateInventory", this::update);
+        entity.getEvents().addListener("updateInventory", this::updateInventory);
         LOGGER.info("PlayerItemSpriteManager created");
     }
 


### PR DESCRIPTION
This PR is in reference to ticket #464 

Small pull request for changes made to player animation to fix the bug where a steak will show as a banana animation. And also to fix the bug of the player animation not instanty updating upon the player recieving or giving at item. (This fix also fixes the bug were whilst moving and getting an item the player animation would not update).

This change also modified some logic to remove redundant checks within the updatePlayerSprite function and also removed the update function from the PlayerItemSpriteManager class in favour of only updating the sprite / animation when an item is added / removed instead of every single frame.

Summary: just some minor bug fixes and modifications