### PR TITLE
Game start fix

### DIFF
--- a/source/core/src/main/com/csse3200/game/services/LevelService.java
+++ b/source/core/src/main/com/csse3200/game/services/LevelService.java
@@ -91,9 +91,9 @@ public class LevelService {
      *
      * @param level the level number
      */
-    public void levelControl(int level) {
-        int spawnCap = 0;
-        switch (level) {
+    public void levelControl(GdxGame.LevelType level) {
+        //int spawnCap = 0;
+        /*switch (level) {
             case 0:
                 spawnCap = 1;
                 break;
@@ -127,7 +127,17 @@ public class LevelService {
             case 10:
                 spawnCap = 17;
                 break;
-        }
+        }*/
+
+        int spawnCap = switch(level) {
+            case LEVEL_1 -> 1;
+            case LEVEL_2 -> 3;
+            case LEVEL_3 -> 4;
+            case LEVEL_4 -> 5;
+            case LEVEL_5 -> 7;
+            case DONE -> 9;
+        };
+
         levelEventHandler.trigger("startSpawning", spawnCap);
     }
 }

--- a/source/core/src/test/com/csse3200/game/services/LevelServiceTest.java
+++ b/source/core/src/test/com/csse3200/game/services/LevelServiceTest.java
@@ -83,13 +83,24 @@ class LevelServiceTest {
         EventHandler eventHandler = new EventHandler();
         doReturn(eventHandler).when(levelServiceSpy).getEvents();
         levelServiceSpy.getEvents().addListener("startSpawning", mockEventListener);
-        for (int i = 0; i < 11; i++) {
-            levelServiceSpy.levelControl(i);
-            verify(levelServiceSpy).levelControl(i);
-            //when(levelServiceSpy.getEvents()).thenReturn(eventHandler);
-            //doReturn(eventHandler).when(levelServiceSpy).getEvents();
-            verify(mockEventListener, atMost(11)).handle(anyInt());
-        }
+
+        levelServiceSpy.levelControl(GdxGame.LevelType.LEVEL_1);
+        verify(levelServiceSpy).levelControl(GdxGame.LevelType.LEVEL_1);
+
+        levelServiceSpy.levelControl(GdxGame.LevelType.LEVEL_2);
+        verify(levelServiceSpy).levelControl(GdxGame.LevelType.LEVEL_2);
+
+        levelServiceSpy.levelControl(GdxGame.LevelType.LEVEL_3);
+        verify(levelServiceSpy).levelControl(GdxGame.LevelType.LEVEL_3);
+
+        levelServiceSpy.levelControl(GdxGame.LevelType.LEVEL_4);
+        verify(levelServiceSpy).levelControl(GdxGame.LevelType.LEVEL_4);
+
+        levelServiceSpy.levelControl(GdxGame.LevelType.LEVEL_5);
+        verify(levelServiceSpy).levelControl(GdxGame.LevelType.LEVEL_5);
+
+        levelServiceSpy.levelControl(GdxGame.LevelType.DONE);
+        verify(levelServiceSpy).levelControl(GdxGame.LevelType.DONE);
     }
 
     @Test


### PR DESCRIPTION
# Fixes #488 

Enables game to start and to run on pressing start

## Changes Made:

### Refactoring `levelControl` Method:

* [`source/core/src/main/com/csse3200/game/services/LevelService.java`](diffhunk://#diff-d9d61d6d9c5b8811a533090a8118f57377dcd7bcc85de18eda8d77af2dc04984L94-R96): Updated `levelControl` method to use `GdxGame.LevelType` enum instead of integers, and refactored the switch statement to use the new enum values. [[1]](diffhunk://#diff-d9d61d6d9c5b8811a533090a8118f57377dcd7bcc85de18eda8d77af2dc04984L94-R96) [[2]](diffhunk://#diff-d9d61d6d9c5b8811a533090a8118f57377dcd7bcc85de18eda8d77af2dc04984L130-R140)

### Updating Test Cases:

* [`source/core/src/test/com/csse3200/game/services/LevelServiceTest.java`](diffhunk://#diff-e55d797280b6f1d6a6745f6335573e91ccb8579c5e70f1c65a173b2c6e9de6f2L86-R103): Modified the `shouldRespondToDifferentIntegersInLevelControl` test to verify the `levelControl` method with the new `GdxGame.LevelType` enum values.