### PR TITLE
Changing listener key to ESC instead of O for pause docket timers #531

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/ordersystem/MainGameOrderTicketDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/ordersystem/MainGameOrderTicketDisplay.java
@@ -164,7 +164,7 @@ public class MainGameOrderTicketDisplay extends UIComponent {
         stage.addListener(new InputListener() {
             @Override
             public boolean keyDown(InputEvent event, int keycode) {
-                if (keycode == com.badlogic.gdx.Input.Keys.O) {
+                if (keycode == com.badlogic.gdx.Input.Keys.ESCAPE) {
                     setPaused(!isPaused);
                     return true;
                 }


### PR DESCRIPTION
# Description

Changing listener key to ESC instead of O for pause docket timers. Now, when the game is paused, the docket ticket timer is paused as well.

Fixes / Closes #531

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
