### PR TITLE
Fixed issue when clicking No Game Crashes

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/cutscenes/CutsceneArea.java
+++ b/source/core/src/main/com/csse3200/game/components/cutscenes/CutsceneArea.java
@@ -4,6 +4,7 @@ import com.csse3200.game.GdxGame;
 import com.csse3200.game.areas.ForestGameArea;
 import com.csse3200.game.areas.GameArea;
 import com.csse3200.game.entities.Entity;
+import com.csse3200.game.services.LevelService;
 import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.ServiceLocator;
 import org.slf4j.Logger;
@@ -31,6 +32,7 @@ public class CutsceneArea extends GameArea {
     public CutsceneArea(GdxGame.CutsceneType cutsceneValue) {
         super();
         ServiceLocator.registerGameArea(this);  // Register this cutscene area in the service locator
+        ServiceLocator.registerLevelService(new LevelService());
         this.cutsceneValue = cutsceneValue;
     }
 


### PR DESCRIPTION
# Description

Fixed issue when clicking No Game Crashes

Fixes / Closes #550 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Clicking start game and clicking 'No' proceeds to Backstory instead of crashing

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
