### PR TITLE
Fully Integrates Win/Loss Logic into Game and Ensures Days Iterate Correctly

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/maingame/CheckWinLoseComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/maingame/CheckWinLoseComponent.java
@@ -55,7 +55,7 @@ public class CheckWinLoseComponent extends Component {
 
         if (hasLost(adjustedLossThreshold)) {
             return "LOSE";
-        } else if (currentDay == DayNightService.MAXDAYS && hasWon(adjustedWinAmount)) {
+        } else if (currentDay == DayNightService.MAX_DAYS && hasWon(adjustedWinAmount)) {
             return "WIN";
         } else {
             return "GAME_IN_PROGRESS";

--- a/source/core/src/main/com/csse3200/game/components/player/PlayerStatsDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/player/PlayerStatsDisplay.java
@@ -10,6 +10,7 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
+import com.badlogic.gdx.scenes.scene2d.utils.BaseDrawable;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.csse3200.game.components.CombatStatsComponent;
 import com.csse3200.game.services.ServiceLocator;
@@ -34,11 +35,12 @@ public class PlayerStatsDisplay extends UIComponent {
 
   private Label goldLabel;
   private static Label dayLabel;
-  private static int currentDay = 1;
   private static Label timerLabel;
   private static long timer;
   private static long startTime;
   private static PlayerStatsDisplay instance;
+  private ProgressBar timeBar;
+  private static final float MAX_TIME = 300f;
 
 
 
@@ -50,7 +52,7 @@ public class PlayerStatsDisplay extends UIComponent {
     super.create();
     setPlayerStatsDisplay(this);
     addActors();
-    setTimer(ServiceLocator.getDayNightService().FIVEMINUTES);
+    setTimer(ServiceLocator.getDayNightService().FIVE_MINUTES);
 
 
     entity.getEvents().addListener("updateGold", this::updatePlayerGoldUI);
@@ -106,8 +108,10 @@ public class PlayerStatsDisplay extends UIComponent {
    */
   private void addActors() {
     table = new Table();
-    table.top().left();  // Position table to the top-left of the screen
+    table.top().left();
     table.setFillParent(true);
+    table.padTop(80f).padLeft(20f);
+
     goldTable = new Table();
     timerTable = new Table();
     dayTable = new Table();
@@ -137,7 +141,7 @@ public class PlayerStatsDisplay extends UIComponent {
     // --- Update: Day Label with Container ---
 
     // Label for the Current Day
-    CharSequence dayText = String.format("Day: %d", currentDay); // Start with Day 1
+    CharSequence dayText = String.format("Day: %d", ServiceLocator.getDayNightService().getDay()); // Start with Day 1
     dayLabel = new Label(dayText, skin, SMALL_LABEL);
     dayLabel.setColor(Color.GOLD);  // Set text color to white for contrast
 
@@ -232,7 +236,7 @@ public class PlayerStatsDisplay extends UIComponent {
    * Updates the displayed current day on the UI.
    */
   public static void updateDay() {
-    currentDay++;
+    int currentDay = ServiceLocator.getDayNightService().getDay();
     CharSequence dayText = String.format("Day: %d", currentDay);
     getDayLabel().setText(dayText);
   }
@@ -260,11 +264,10 @@ public class PlayerStatsDisplay extends UIComponent {
   public static void updateTime(long time) {
     timer = time;
 
-//    // Calculate progress as a percentage of the time remaining
-//    float progressPercentage = (float) timer / startTime * 100f;
-//
-//    // Update the progress bar value to reflect the remaining time
-//    getInstance().timeBar.setValue(progressPercentage);
+    // Calculate progress as a percentage of the time remaining
+    float progressPercentage = (float) time / ServiceLocator.getDayNightService().FIVE_MINUTES * 100f;
+
+    //float progressPercentage = (float) timer / startTime * 100f;
 
     // Update the timer color based on remaining time
     updateTimeColor();
@@ -339,10 +342,10 @@ public class PlayerStatsDisplay extends UIComponent {
     long minutes = TimeUnit.MILLISECONDS.toMinutes(x);
     long seconds = TimeUnit.MILLISECONDS.toSeconds(x) - TimeUnit.MINUTES.toSeconds(minutes);
     return String.format("%02d:%02d", minutes, seconds);
-    
+
 }
 public static void reset() {
-  currentDay = 1;
+    ServiceLocator.getDayNightService().setDay(1);
 }
 
 

--- a/source/core/src/main/com/csse3200/game/screens/MoralDecisionDisplay.java
+++ b/source/core/src/main/com/csse3200/game/screens/MoralDecisionDisplay.java
@@ -188,6 +188,7 @@ public class MoralDecisionDisplay extends UIComponent {
         isVisible = false;
         layout.setVisible(isVisible);
         game.resume(); // Resume the game when the display is hidden
+        logger.info("decisionDone about to be triggered");
         ServiceLocator.getDayNightService().getEvents().trigger("decisionDone");
 
     }

--- a/source/core/src/main/com/csse3200/game/services/DayNightService.java
+++ b/source/core/src/main/com/csse3200/game/services/DayNightService.java
@@ -187,6 +187,7 @@ public class DayNightService {
             }
         }
 
+        // transition to new day
         day += 1;
         logger.info("Next/new day is: " + day);
 
@@ -202,7 +203,6 @@ public class DayNightService {
         lastSecondCheck = gameTime.getTime(); // Reset lastCheckTime to the current time
         lastEndOfDayCheck = gameTime.getTime();
         gameTime.setTimeScale(1); // Resume game time
-
 
     }
 

--- a/source/core/src/test/com/csse3200/game/components/CheckWinLoseComponentTest.java
+++ b/source/core/src/test/com/csse3200/game/components/CheckWinLoseComponentTest.java
@@ -47,9 +47,9 @@ public class CheckWinLoseComponentTest {
 
     @Test
     public void testCheckGameStateReturnsWinOnlyOnFinalDay() {
-        when(dayNightService.getDay()).thenReturn(DayNightService.MAXDAYS);
+        when(dayNightService.getDay()).thenReturn(DayNightService.MAX_DAYS);
 
-        int adjustedWinAmount = 55 + (DayNightService.MAXDAYS * 10);
+        int adjustedWinAmount = 55 + (DayNightService.MAX_DAYS * 10);
         int playerGold = adjustedWinAmount + 5;
         when(combatStatsComponent.getGold()).thenReturn(playerGold);
 
@@ -93,9 +93,9 @@ public class CheckWinLoseComponentTest {
 
     @Test
     public void testCheckGameStateReturnsGameInProgressWhenGoldAboveWinAmountBeforeFinalDay() {
-        when(dayNightService.getDay()).thenReturn(DayNightService.MAXDAYS - 1);
+        when(dayNightService.getDay()).thenReturn(DayNightService.MAX_DAYS - 1);
 
-        int adjustedWinAmount = 55 + ((DayNightService.MAXDAYS - 1) * 10);
+        int adjustedWinAmount = 55 + ((DayNightService.MAX_DAYS - 1) * 10);
         int playerGold = adjustedWinAmount + 10;
         when(combatStatsComponent.getGold()).thenReturn(playerGold);
 
@@ -155,9 +155,9 @@ public class CheckWinLoseComponentTest {
 
     @Test
     public void testCheckGameStateWhenGoldEqualsWinAmountOnFinalDay() {
-        when(dayNightService.getDay()).thenReturn(DayNightService.MAXDAYS);
+        when(dayNightService.getDay()).thenReturn(DayNightService.MAX_DAYS);
 
-        int adjustedWinAmount = 55 + (DayNightService.MAXDAYS * 10);
+        int adjustedWinAmount = 55 + (DayNightService.MAX_DAYS * 10);
         when(combatStatsComponent.getGold()).thenReturn(adjustedWinAmount);
 
         playerService.getEvents().trigger("playerCreated", playerEntity);


### PR DESCRIPTION
# Description

Changes were made to PlayerStatsDisplay so that it uses the 'day' as dictated by DayNightService, as opposed to using its own local variable. Additionally, a bug within DayNightService was resolved, which was previously preventing the days form iterating correctly. The DayNightServiceTest class was also updated to reflect the logic changes to DayNightService that were made to resolve the iteration bug. 

Fixes / Closes # (issue)
#602
#601

## Type of change

- [x] Bug fix of days iterating incorrectly
- [x] Ensures PlayerStatsDisplay uses DayNightService 'day' instead of its own local version of 'day'

# How Has This Been Tested?

- [x] DayNightServiceTest.java class 
- [x] Code was visually tested via running the game. It successfully iterated through all 5 days and played the correct final cutscene according to various gold levels 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
