### PR TITLE
Pressing Enter crashes the game out of bounds 

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/maingame/TextDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/maingame/TextDisplay.java
@@ -348,17 +348,19 @@ public class TextDisplay extends UIComponent {
                     }
                     return true;
                 } else if (keycode == com.badlogic.gdx.Input.Keys.ENTER) {
-                    if (charIndex < TextDisplay.this.text.get(currentPart).length()) {
-                        label.setText(text.get(currentPart));
-                        charIndex = TextDisplay.this.text.get(currentPart).length();
-                    } else {
-                        currentPart++;
-                        charIndex = 0;
-                        lastUpdate = 0;
-                        TextDisplay.this.currentText = new StringBuilder();
-                        // if no more text remaining
-                        if (currentPart == TextDisplay.this.text.size()) {
-                            setVisible(false);
+                    if (currentPart < text.size()) {
+                        if (charIndex < TextDisplay.this.text.get(currentPart).length()) {
+                            label.setText(text.get(currentPart));
+                            charIndex = TextDisplay.this.text.get(currentPart).length();
+                        } else {
+                            currentPart++;
+                            charIndex = 0;
+                            lastUpdate = 0;
+                            TextDisplay.this.currentText = new StringBuilder();
+                            // if no more text remaining
+                            if (currentPart == TextDisplay.this.text.size()) {
+                                setVisible(false);
+                            }
                         }
                     }
                     return true;

--- a/source/core/src/main/com/csse3200/game/components/tutorial/TutorialScreenDisplay.java
+++ b/source/core/src/main/com/csse3200/game/components/tutorial/TutorialScreenDisplay.java
@@ -257,39 +257,39 @@ public class TutorialScreenDisplay extends UIComponent {
             switch (tutorialStep) {
                 case 1:
                     if (Gdx.input.isKeyJustPressed(Input.Keys.W) || Gdx.input.isKeyJustPressed(Input.Keys.A) ||
-                            Gdx.input.isKeyJustPressed(Input.Keys.S) || Gdx.input.isKeyJustPressed(Input.Keys.D)) {
+                            Gdx.input.isKeyJustPressed(Input.Keys.S) || Gdx.input.isKeyJustPressed(Input.Keys.D) || Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
                         advanceTutorialStep();
                     }
                     break;
                 case 2:
-                    if (Gdx.input.isKeyJustPressed(Input.Keys.E)) {
+                    if (Gdx.input.isKeyJustPressed(Input.Keys.E) || Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
                         advanceTutorialStep();
                     }
                     break;
                 case 3:
-                    if (Gdx.input.isKeyJustPressed(Input.Keys.LEFT_BRACKET) || Gdx.input.isKeyJustPressed(Input.Keys.RIGHT_BRACKET)) {
+                    if (Gdx.input.isKeyJustPressed(Input.Keys.LEFT_BRACKET) || Gdx.input.isKeyJustPressed(Input.Keys.RIGHT_BRACKET) || Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
                         docketsShifted = true;
                         logger.debug("Dockets shifted!");
                         advanceTutorialStep();
                     }
                     break;
                 case 4:
-                    if (Gdx.input.isKeyJustPressed(Input.Keys.R)) {
+                    if (Gdx.input.isKeyJustPressed(Input.Keys.R) || Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
                         advanceTutorialStep();
                     }
                     break;
                 case 5:
-                    if (Gdx.input.isKeyJustPressed(Input.Keys.Q)) {
+                    if (Gdx.input.isKeyJustPressed(Input.Keys.Q) || Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
                         advanceTutorialStep();
                     }
                     break;
                 case 6:
-                    if (Gdx.input.isKeyJustPressed(Input.Keys.K)) {
+                    if (Gdx.input.isKeyJustPressed(Input.Keys.K) || Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
                         advanceTutorialStep();
                     }
                     break;
                 case 7:
-                    if (Gdx.input.isKeyJustPressed(Input.Keys.J)) {
+                    if (Gdx.input.isKeyJustPressed(Input.Keys.J) || Gdx.input.isKeyJustPressed(Input.Keys.ENTER)) {
                         advanceTutorialStep();
                     }
                     break;


### PR DESCRIPTION
# Description

Pressing Enter crashes the game out of bounds. Fix was similar to update() method in TextDisplay.java

Fixes / Closes #650 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Go into tutorials, and wait for a text box to finish rendering, press 'Enter'

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
